### PR TITLE
Bump holoscan to 3.1.0.3

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,6 +16,27 @@ jobs:
   variables: {}
 
   steps:
+  - script: |
+         sudo mkdir -p /opt/empty_dir || true
+         for d in \
+                  /opt/ghc \
+                  /opt/hostedtoolcache \
+                  /usr/lib/jvm \
+                  /usr/local/.ghcup \
+                  /usr/local/lib/android \
+                  /usr/local/share/powershell \
+                  /usr/share/dotnet \
+                  /usr/share/swift \
+                  ; do
+           sudo rsync --stats -a --delete /opt/empty_dir/ $d || true
+         done
+         sudo apt-get purge -y -f firefox \
+                                  google-chrome-stable \
+                                  microsoft-edge-stable
+         sudo apt-get autoremove -y >& /dev/null
+         sudo apt-get autoclean -y >& /dev/null
+         df -h
+    displayName: Manage disk space
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,30 +70,37 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
     p.add_argument(
         "--debug",
         action="store_true",
@@ -104,6 +121,8 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
         recipe_license_file = os.path.join(
             "recipe", "recipe-scripts-license.txt"

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,5 @@
+azure:
+  free_disk_space: true
 github:
   branch_name: main
   tooling_branch_name: main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,6 @@
-{% set version = "3.0.0.9" %}
+{% set version = "3.1.0.3" %}
+{% set abiversion = version.split('.')[0] %}
+{% set libversion = version.split('.')[:3] | join('.') %}
 {% set cuda_version = "12.6" %}      # min version holoscan works with
 {% set libtorch_version = "2.5.*" %}
 {% set onnx_version = "1.18.1.*" %}
@@ -9,7 +11,7 @@
 {% set platform = "linux-sbsa" %}    # [aarch64]
 {% set extension = "tar.xz" %}
 
-{% set sha256 = "3ed03c5f8882975d4241f1a798a78ceea5c91b1ad5278c9db50105d1a8266a28" %}  # [linux64]
+{% set sha256 = "12718d5a5342a5b5c8bf3f9a5673a7bfb9dd634edfe74c590dec70df48975128" %}  # [linux64]
 {% set sha256 = "d6a36bfa06217893fb79bf8affdb31a4d3942953c7d602918e2655ccf01acb25" %}  # [aarch64 and arm_variant_type == "sbsa"]
 {% set sha256 = "c3e49c05eae6de09f0bbd37b55874754f9209f941a07a34770b5b047960a073d" %}  # [aarch64 and arm_variant_type == "tegra"]
 
@@ -79,7 +81,6 @@ outputs:
         - cuda-nvtx         # needed to fix broken symlinks: libnvToolsExt.so.1.0.0 -> ../targets/x86_64-linux/lib/libnvToolsExt.so.1.0.0
         - cudnn
         - libegl
-        - libgomp
         - libcublas
         - libcufft
         - libcurand
@@ -92,60 +93,61 @@ outputs:
         - libtorch * cuda*
         - libvulkan-loader
         - libzlib
+        - llvm-openmp 19.*
         - nccl
         - rdma-core
     test:
       commands:
-        - test -L $PREFIX/lib/libholoscan_core.so.3
-        - test -L $PREFIX/lib/libholoscan_infer.so.3
-        - test -L $PREFIX/lib/libholoscan_infer_onnx_runtime.so.3
-        - test -L $PREFIX/lib/libholoscan_infer_torch.so.3
-        - test -L $PREFIX/lib/libholoscan_infer_utils.so.3
-        - test -L $PREFIX/lib/libholoscan_logger.so.3
-        - test -L $PREFIX/lib/libholoscan_op_async_ping_rx.so.3
-        - test -L $PREFIX/lib/libholoscan_op_async_ping_tx.so.3
-        - test -L $PREFIX/lib/libholoscan_op_bayer_demosaic.so.3
-        - test -L $PREFIX/lib/libholoscan_op_format_converter.so.3
-        - test -L $PREFIX/lib/libholoscan_op_gxf_codelet.so.3
-        - test -L $PREFIX/lib/libholoscan_op_holoviz.so.3
-        - test -L $PREFIX/lib/libholoscan_op_inference.so.3
-        - test -L $PREFIX/lib/libholoscan_op_inference_processor.so.3
-        - test -L $PREFIX/lib/libholoscan_op_ping_rx.so.3
-        - test -L $PREFIX/lib/libholoscan_op_ping_tensor_rx.so.3
-        - test -L $PREFIX/lib/libholoscan_op_ping_tensor_tx.so.3
-        - test -L $PREFIX/lib/libholoscan_op_ping_tx.so.3
-        - test -L $PREFIX/lib/libholoscan_op_segmentation_postprocessor.so.3
-        - test -L $PREFIX/lib/libholoscan_op_v4l2.so.3
-        - test -L $PREFIX/lib/libholoscan_op_video_stream_recorder.so.3
-        - test -L $PREFIX/lib/libholoscan_op_video_stream_replayer.so.3
-        - test -L $PREFIX/lib/libholoscan_profiler.so.3
-        - test -L $PREFIX/lib/libholoscan_spdlog_logger.so.3
-        - test -L $PREFIX/lib/libholoscan_viz.so.3
-        - test -f $PREFIX/lib/libholoscan_core.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_infer.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_infer_onnx_runtime.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_infer_torch.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_infer_utils.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_logger.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_op_async_ping_rx.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_op_async_ping_tx.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_op_bayer_demosaic.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_op_format_converter.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_op_gxf_codelet.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_op_holoviz.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_op_inference.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_op_inference_processor.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_op_ping_rx.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_op_ping_tensor_rx.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_op_ping_tensor_tx.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_op_ping_tx.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_op_segmentation_postprocessor.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_op_v4l2.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_op_video_stream_recorder.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_op_video_stream_replayer.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_profiler.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_spdlog_logger.so.3.0.0
-        - test -f $PREFIX/lib/libholoscan_viz.so.3.0.0
+        - test -L $PREFIX/lib/libholoscan_core.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_infer.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_infer_onnx_runtime.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_infer_torch.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_infer_utils.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_logger.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_op_async_ping_rx.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_op_async_ping_tx.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_op_bayer_demosaic.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_op_format_converter.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_op_gxf_codelet.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_op_holoviz.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_op_inference.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_op_inference_processor.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_op_ping_rx.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_op_ping_tensor_rx.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_op_ping_tensor_tx.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_op_ping_tx.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_op_segmentation_postprocessor.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_op_v4l2.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_op_video_stream_recorder.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_op_video_stream_replayer.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_profiler.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_spdlog_logger.so.{{ abiversion }}
+        - test -L $PREFIX/lib/libholoscan_viz.so.{{ abiversion }}
+        - test -f $PREFIX/lib/libholoscan_core.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_infer.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_infer_onnx_runtime.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_infer_torch.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_infer_utils.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_logger.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_op_async_ping_rx.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_op_async_ping_tx.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_op_bayer_demosaic.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_op_format_converter.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_op_gxf_codelet.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_op_holoviz.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_op_inference.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_op_inference_processor.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_op_ping_rx.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_op_ping_tensor_rx.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_op_ping_tensor_tx.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_op_ping_tx.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_op_segmentation_postprocessor.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_op_v4l2.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_op_video_stream_recorder.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_op_video_stream_replayer.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_profiler.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_spdlog_logger.so.{{ libversion }}
+        - test -f $PREFIX/lib/libholoscan_viz.so.{{ libversion }}
         - test -f $PREFIX/lib/libgxf_app.so
         - test -f $PREFIX/lib/libgxf_core.so
         - test -f $PREFIX/lib/libgxf_cuda.so


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

- bump version
- parameterize the `libversion` and `abiversion`
- no longer need to expliclty specify `libgomp`
- explicitly add `llvm-openmp 19.*` rather than let transitive dependency picking up `llvm-openmp 20.*`, which contains `libgomp` and causes clobbering issues with `_openmp_mutex` which contains same thing

Note: no support for `linux-aarch64` (sbsa) yet, which is being dealt with in another PR (https://github.com/conda-forge/holoscan-feedstock/pull/1)

<!--
Please add any other relevant info below:
-->
