### PR TITLE
Support SBSA in holoscan 3.1.0.3

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,6 +12,10 @@ jobs:
         CONFIG: linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13:
+        CONFIG: linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13.yaml
@@ -1,0 +1,46 @@
+arm_variant_type:
+- sbsa
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.34'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- '12.6'
+cudnn:
+- '9'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+dbus:
+- '1'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+libjpeg_turbo:
+- '3'
+nccl:
+- '2'
+rdma_core:
+- '55'
+target_platform:
+- linux-aarch64
+xz:
+- '5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+  - cuda_compiler
+  - cuda_compiler_version
+  - docker_image

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/holoscan-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=25118&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/holoscan-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_c_compiler_version13cuda_compilercuda-nvcccuda_compiler_version12.6cxx_compiler_version13" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,8 +1,14 @@
 azure:
   free_disk_space: true
-github:
-  branch_name: main
-  tooling_branch_name: main
+build_platform:
+  linux_64: linux_64
+  linux_aarch64: linux_64
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
+github:
+  branch_name: main
+  tooling_branch_name: main
+provider:
+  linux_64: default
+  linux_aarch64: default

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,7 @@
 {% set extension = "tar.xz" %}
 
 {% set sha256 = "12718d5a5342a5b5c8bf3f9a5673a7bfb9dd634edfe74c590dec70df48975128" %}  # [linux64]
-{% set sha256 = "d6a36bfa06217893fb79bf8affdb31a4d3942953c7d602918e2655ccf01acb25" %}  # [aarch64 and arm_variant_type == "sbsa"]
-{% set sha256 = "c3e49c05eae6de09f0bbd37b55874754f9209f941a07a34770b5b047960a073d" %}  # [aarch64 and arm_variant_type == "tegra"]
+{% set sha256 = "6c067a98404a8a6f020f49d76cf7fde09319a69c6245ae84cd93079971ac622b" %}  # [aarch64 and arm_variant_type == "sbsa"]
 
 package:
   name: holoscan-split
@@ -24,13 +23,15 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not (linux64 or aarch64)]
   skip: true  # [cuda_compiler_version in (None, "None", "") or (cuda_compiler_version or "").startswith("11")]
 
 requirements:
   build:
     - cf-nvidia-tools 1  # [linux]
+    - python ={{ python_version }}
+  host:
     - python ={{ python_version }}
 
 outputs:
@@ -65,13 +66,14 @@ outputs:
         - cuda-version {{ cuda_version }}
         - libjpeg-turbo
         - libnpp-dev
+        - libnuma           # [aarch64]
         - libtorch {{ libtorch_version }}
         - libtorch * cuda*
         - libvulkan-loader
         - rdma-core
         - ucx {{ ucx_version }}
-        - yaml-cpp  {{ yaml_cpp_version }}
         - onnxruntime-cpp  {{ onnx_version }}
+        - yaml-cpp  {{ yaml_cpp_version }}
       run:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
         - {{ pin_compatible("cuda-version", max_pin="x") }}  # [cuda_compiler_version != "None"]
@@ -80,6 +82,7 @@ outputs:
         - cuda-nvrtc-dev    # holoscan wants to explicitly install cuda-nvrtc-dev
         - cuda-nvtx         # needed to fix broken symlinks: libnvToolsExt.so.1.0.0 -> ../targets/x86_64-linux/lib/libnvToolsExt.so.1.0.0
         - cudnn
+        - dbus              # [aarch64]  # Without this, segfault happens during camera app test in https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/python
         - libegl
         - libcublas
         - libcufft
@@ -89,6 +92,7 @@ outputs:
         - libjpeg-turbo
         - libnpp            # needed on its own as libs depend on it
         - libnpp-dev        # holoscan wants to explicitly install libnpp-dev
+        - libnuma           # [aarch64]
         - libnvjitlink
         - libtorch * cuda*
         - libvulkan-loader


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
- added `libnuma` only for `aarch64`
- added `dbus` only for `aarch64`, even as it is not a hard-dependency. This is to make pytest from https://github.com/nvidia-holoscan/holoscan-sdk pass. It might be that `dbus` would have been a dependency of something that is whitelisted as not available in conda-forge
- had to list `python ={{ python_version }`} as host dependency for `aarch64` CI to work (but it works for `linux-64` too)

Note: closing https://github.com/conda-forge/holoscan-feedstock/pull/1 because that was for `holoscan` 3.0.0.9 and we were troubleshooting segfault issue with pytest which is now resolved by adding `dbus` for `holoscan` 3.1.0.3. Holoscan is OK supporting sbsa starting with 3.1.0.3

<!--
Please add any other relevant info below:
-->
