### PR TITLE
Add libholoscan-dev for C++ SDK

### DIFF
--- a/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13.yaml
+++ b/.ci_support/linux_64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13.yaml
@@ -24,6 +24,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libjpeg_turbo:
 - '3'
+openssl:
+- '3'
 rdma_core:
 - '55'
 target_platform:

--- a/.ci_support/linux_aarch64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version13cuda_compiler_version12.6cxx_compiler_version13.yaml
@@ -26,6 +26,8 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libjpeg_turbo:
 - '3'
+openssl:
+- '3'
 rdma_core:
 - '55'
 target_platform:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Package license: [LicenseRef-NVIDIA-End-User-License-Agreement](https://develope
 
 Summary: NVIDIA Holoscan runtime library
 
-This is a runtime package only. Developers should install holoscan (python) to build with Holoscan
+This is a runtime package only. Developers should install holoscan (python) and/or libholoscan-dev (C++ SDK) to build with Holoscan
 
 
 Current build status
@@ -89,6 +89,7 @@ Current release info
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-holoscan-green.svg)](https://anaconda.org/conda-forge/holoscan) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/holoscan.svg)](https://anaconda.org/conda-forge/holoscan) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/holoscan.svg)](https://anaconda.org/conda-forge/holoscan) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/holoscan.svg)](https://anaconda.org/conda-forge/holoscan) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-libholoscan-green.svg)](https://anaconda.org/conda-forge/libholoscan) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libholoscan.svg)](https://anaconda.org/conda-forge/libholoscan) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libholoscan.svg)](https://anaconda.org/conda-forge/libholoscan) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libholoscan.svg)](https://anaconda.org/conda-forge/libholoscan) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-libholoscan--dev-green.svg)](https://anaconda.org/conda-forge/libholoscan-dev) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/libholoscan-dev.svg)](https://anaconda.org/conda-forge/libholoscan-dev) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/libholoscan-dev.svg)](https://anaconda.org/conda-forge/libholoscan-dev) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/libholoscan-dev.svg)](https://anaconda.org/conda-forge/libholoscan-dev) |
 
 Installing holoscan
 ===================
@@ -100,16 +101,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `holoscan, libholoscan` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `holoscan, libholoscan, libholoscan-dev` can be installed with `conda`:
 
 ```
-conda install holoscan libholoscan
+conda install holoscan libholoscan libholoscan-dev
 ```
 
 or with `mamba`:
 
 ```
-mamba install holoscan libholoscan
+mamba install holoscan libholoscan libholoscan-dev
 ```
 
 It is possible to list all of the versions of `holoscan` available on your platform with `conda`:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,7 +9,6 @@ mkdir -p $PREFIX/NOTICE
 mkdir -p $SP_DIR
 echo "site-packages dir, SP_DIR = $SP_DIR"
 
-rm -v lib/libyaml-cpp*
 rm -vr include/yaml-cpp
 
 rm -v lib/libuc[mpst]*

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,8 +3,6 @@
 set -e
 set -x
 
-mkdir -p $PREFIX/NOTICE
-
 # Create the site-packages dir if it doesn't exist
 mkdir -p $SP_DIR
 echo "site-packages dir, SP_DIR = $SP_DIR"
@@ -17,7 +15,6 @@ rm -vr lib/ucx
 check-glibc bin/* lib/* lib/ucx/* lib/gxf_extensions/*
 find python/ -name "*.so*" | xargs -I"{}" check-glibc "{}"
 
-cp -v NOTICE $PREFIX/NOTICE
 cp -rv bin $PREFIX/
 cp -rv examples $PREFIX/
 cp -rv lib $PREFIX/

--- a/recipe/compile_examples.sh
+++ b/recipe/compile_examples.sh
@@ -26,6 +26,9 @@ export CXXFLAGS="${CXXFLAGS} -fno-use-linker-plugin"
 echo CC = $CC
 echo CXX = $CXX
 
+# CMAKE test references libyaml-cpp.a so copy it to $PREFIX, even as we do not ship it
+cp -vf "$SRC_DIR/lib/libyaml-cpp.a" "$PREFIX/lib/"
+
 cmake -S $PREFIX/examples ${CMAKE_ARGS}
 
 cmake --build .

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,8 +72,8 @@ outputs:
         - libvulkan-loader
         - rdma-core
         - ucx {{ ucx_version }}
-        - onnxruntime-cpp  {{ onnx_version }}
         - yaml-cpp  {{ yaml_cpp_version }}
+        - onnxruntime-cpp  {{ onnx_version }}
       run:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
         - {{ pin_compatible("cuda-version", max_pin="x") }}  # [cuda_compiler_version != "None"]
@@ -172,11 +172,10 @@ outputs:
       license_url: https://developer.download.nvidia.com/assets/Clara/NVIDIA_Clara_EULA.pdf
       summary: NVIDIA Holoscan runtime library
       description: |
-        This is a runtime package only. Developers should install holoscan (python) to build with Holoscan
+        This is a runtime package only. Developers should install holoscan (python) and/or libholoscan-dev (C++ SDK) to build with Holoscan
 
   - name: holoscan
     files:
-      - examples/
       - lib/python{{ python_version }}/site-packages/gxf
       - lib/python{{ python_version }}/site-packages/holoscan
     requirements:
@@ -215,13 +214,9 @@ outputs:
 
   - name: libholoscan-dev
     build:
-      # FIXME: Unskip dev package after removing revended packages.
-      skip: true
       run_exports:
         - {{ pin_subpackage("libholoscan", max_pin="x") }}
     files:
-      # FIXME: Figure out a better way to deliver the readme text. Conda package description? Print to terminal as an activation script?
-      - bin/README.md
       - bin/convert_gxf_entities_to_images.py
       - bin/convert_gxf_entities_to_video.py
       - bin/convert_video_to_gxf_entities.py
@@ -245,7 +240,20 @@ outputs:
       - include/magic_enum.hpp
       - include/rmm
       - lib/libholoscan*.so
-      - lib/cmake
+      - lib/cmake/holoscan/holoscan-targets-release.cmake
+      - lib/cmake/holoscan/wrap_operator_as_gxf_template/extension.cpp.in
+      - lib/cmake/holoscan/wrap_operator_as_gxf_template/codelet.cpp.in
+      - lib/cmake/holoscan/wrap_operator_as_gxf_template/codelet.hpp.in
+      - lib/cmake/holoscan/HoloscanDownloadData.cmake
+      - lib/cmake/holoscan/holoscan-config.cmake
+      - lib/cmake/holoscan/WrapOperatorAsGXFExtension.cmake
+      - lib/cmake/holoscan/GenerateGXEApp.cmake
+      - lib/cmake/holoscan/holoscan-config-version.cmake
+      - lib/cmake/holoscan/wrap_resource_as_gxf_template/component.cpp.in
+      - lib/cmake/holoscan/wrap_resource_as_gxf_template/component.hpp.in
+      - lib/cmake/holoscan/WrapAsGXFComponent.cmake
+      - lib/cmake/holoscan/holoscan-targets.cmake
+      - lib/cmake/holoscan/holoscan-dependencies.cmake
       - lib/libholo*.a
     requirements:
       build:
@@ -257,8 +265,8 @@ outputs:
         - {{ pin_subpackage("libholoscan", exact=True) }}
         - cuda-cudart-dev
         - cuda-version {{ cuda_version }}
-      run:
         - python ={{ python_version }}
+      run:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
         - {{ pin_subpackage("libholoscan", exact=True) }}
     test:
@@ -273,8 +281,9 @@ outputs:
         - patch  # needed by one of the examples
       files:
         - compile_examples.sh
+      source_files:
+        - lib/libyaml-cpp.a
       commands:
-        - test -f $PREFIX/bin/README.md
         - test -f $PREFIX/bin/convert_gxf_entities_to_images.py
         - test -f $PREFIX/bin/convert_gxf_entities_to_video.py
         - test -f $PREFIX/bin/convert_video_to_gxf_entities.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,7 +65,6 @@ outputs:
       host:
         - cuda-version {{ cuda_version }}
         - cuda-nvrtc-dev
-        - cupy
         - libjpeg-turbo
         - libnpp-dev
         - libtorch {{ libtorch_version }}
@@ -79,7 +78,6 @@ outputs:
         - {{ pin_compatible("cuda-version", max_pin="x") }}  # [cuda_compiler_version != "None"]
         - cloudpickle
         - cuda-cudart
-        - cupy
         - dbus              # [aarch64]  # Without this, segfault happens during camera app test in https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/python
         - libegl
         - libjpeg-turbo
@@ -176,6 +174,7 @@ outputs:
         - cuda-version {{ cuda_version }}
         - python ={{ python_version }}
       run:
+        - cupy
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
         - {{ pin_subpackage("libholoscan", exact=True) }}
         - cuda-cudart
@@ -256,6 +255,7 @@ outputs:
       run:
         - {{ pin_subpackage("libholoscan", exact=True) }}
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        - cuda-nvcc         # holoscan wants to explicitly install this as it is needed for holoscan public interface
         - cuda-cudart
         - cuda-cudart-dev   # holoscan wants to explicitly install this as it is needed for holoscan public interface
         - cuda-nvrtc-dev    # holoscan wants to explicitly install this as it is needed for holoscan public interface

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,10 +1,10 @@
-{% set version = "3.2.0.2" %}
+{% set version = "3.3.0.0" %}
 {% set abiversion = version.split('.')[0] %}
 {% set libversion = version.split('.')[:3] | join('.') %}
 {% set cuda_version = "12.6" %}      # min version holoscan works with
 {% set libtorch_version = "2.5.*" %}
 {% set onnx_version = "1.18.1.*" %}
-{% set python_version = "3.10" %}    # holoscan python libs compiled for python 3.10
+{% set python_version = "3.12" %}    # holoscan python libs compiled for python 3.12
 {% set ucx_version = "1.17.0.*" %}
 {% set yaml_cpp_version = "0.7.0.*" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
@@ -49,6 +49,7 @@ outputs:
       ignore_run_exports_from:
         - {{ compiler('cuda') }}
         - libnpp-dev  # libnpp is tied to specific cuda-version at x.x, so relax it, as we support cuda-version >= 12.6, < 13
+      post-link: post-link
     files:
       - NOTICE/NOTICE
       - lib/libholoscan*.so.*
@@ -70,6 +71,7 @@ outputs:
         - libtorch {{ libtorch_version }}
         - libtorch * cuda*
         - libvulkan-loader
+        - openssl
         - rdma-core
         - ucx {{ ucx_version }}
         - yaml-cpp  {{ yaml_cpp_version }}
@@ -176,7 +178,7 @@ outputs:
 
   - name: holoscan
     files:
-      - lib/python{{ python_version }}/site-packages/gxf
+      #- lib/python{{ python_version }}/site-packages/gxf  # Dropped GXP support in holoscan 3.3.0 with GXF 5.5.0. It may be added back in the future.
       - lib/python{{ python_version }}/site-packages/holoscan
     requirements:
       build:
@@ -193,15 +195,14 @@ outputs:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
         - {{ pin_subpackage("libholoscan", exact=True) }}
         - cuda-cudart
-        - python ={{ python_version }}
     test:
       imports:
         - holoscan
-        - gxf
+        #- gxf  # Dropped GXP support in holoscan 3.3.0 with GXF 5.5.0. It may be added back in the future
       requires:
         - pip
       commands:
-        - test -d $PREFIX/lib/python{{ python_version }}/site-packages/gxf
+        #- test -d $PREFIX/lib/python{{ python_version }}/site-packages/gxf  # Dropped GXP support in holoscan 3.3.0 with GXF 5.5.0. It may be added back in the future.
         - test -d $PREFIX/lib/python{{ python_version }}/site-packages/holoscan
         - pip check
     about:
@@ -227,6 +228,7 @@ outputs:
       - bin/graph_surgeon.py
       - bin/gxe
       - bin/gxf_entity_codec.py
+      - bin/get_cmake_cuda_archs.py
       - bin/holoscan
       - bin/video_validation.py
       - examples/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.3.0.0" %}
+{% set version = "3.3.0.1" %}
 {% set abiversion = version.split('.')[0] %}
 {% set libversion = version.split('.')[:3] | join('.') %}
 {% set cuda_version = "12.6" %}      # min version holoscan works with
@@ -296,6 +296,7 @@ outputs:
         - test -f $PREFIX/bin/graph_surgeon.py
         - test -f $PREFIX/bin/gxe
         - test -f $PREFIX/bin/gxf_entity_codec.py
+        - test -f $PREFIX/bin/get_cmake_cuda_archs.py
         - test -f $PREFIX/bin/holoscan
         - test -f $PREFIX/bin/video_validation.py
         - test -d $PREFIX/lib/cmake/holoscan

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,9 @@
 {% set platform = "linux-sbsa" %}    # [aarch64]
 {% set extension = "tar.xz" %}
 
-{% set sha256 = "e8c673a1fdd23e86087a8617e6017fb1dd1810e1c137ce2fcdcf8af8cfb2b2a6" %}  # [linux64]
-{% set sha256 = "bd9290c8c4d5b8a2716fb0207a73d5d6934e560aabd5cf70ae6626f5e98b5fc0" %}  # [aarch64 and arm_variant_type == "sbsa"]
+
+{% set sha256 = "5ee952a95c596f80135561b20dae27ae7dada192e9172758989911958bb3a46a" %}  # [linux64]
+{% set sha256 = "516e54ca28b007ddaa408f707b2048b67e2b0f1f59ac9578a3a05e861bbb49e9" %}  # [aarch64 and arm_variant_type == "sbsa"]
 
 package:
   name: holoscan-split
@@ -46,12 +47,11 @@ outputs:
         - "*libtorchvision.so*"       # not available even in torchvision package
         - "*libv4l2.so*"              # lideo4linux2 lib, not available
         - "*libxpmem.so*"             # XPMEM, Linux Cross-Memory Attach kernel module, not available
-      ignore_run_exports_from:
-        - {{ compiler('cuda') }}
-        - libnpp-dev  # libnpp is tied to specific cuda-version at x.x, so relax it, as we support cuda-version >= 12.6, < 13
+      ignore_run_exports:
+        # we support cuda-version >= 12.6, < 13
+        - cuda-version
       post-link: post-link
     files:
-      - NOTICE/NOTICE
       - lib/libholoscan*.so.*
       - lib/gxf_extensions
       - lib/libgxf*.so
@@ -170,7 +170,9 @@ outputs:
         - test -f $PREFIX/lib/gxf_extensions/libgxf_ucx_holoscan_lib.so
     about:
       license: LicenseRef-NVIDIA-End-User-License-Agreement
-      license_file: LICENSE
+      license_file:
+        - LICENSE
+        - NOTICE
       license_url: https://developer.download.nvidia.com/assets/Clara/NVIDIA_Clara_EULA.pdf
       summary: NVIDIA Holoscan runtime library
       description: |
@@ -207,7 +209,9 @@ outputs:
         - pip check
     about:
       license: LicenseRef-NVIDIA-End-User-License-Agreement
-      license_file: LICENSE
+      license_file:
+        - LICENSE
+        - NOTICE
       license_url: https://developer.download.nvidia.com/assets/Clara/NVIDIA_Clara_EULA.pdf
       summary: NVIDIA Holoscan python bindings
       description: |
@@ -341,7 +345,9 @@ outputs:
 about:
   home: https://docs.nvidia.com/cuda/holoscan/
   license: LicenseRef-NVIDIA-End-User-License-Agreement
-  license_file: LICENSE
+  license_file:
+    - LICENSE
+    - NOTICE
   license_url: https://developer.download.nvidia.com/assets/Clara/NVIDIA_Clara_EULA.pdf
   summary: NVIDIA Holoscan is the AI sensor processing platform that combines hardware systems for low-latency sensor and network connectivity, optimized libraries for data processing and AI, and core microservices to run streaming, imaging, and other applications, from embedded to edge to cloud.
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,45 +63,28 @@ outputs:
         - {{ stdlib("c") }}
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
       host:
-        - cuda-cudart-dev
         - cuda-version {{ cuda_version }}
+        - cuda-nvrtc-dev
+        - cupy
         - libjpeg-turbo
         - libnpp-dev
-        - libnuma           # [aarch64]
         - libtorch {{ libtorch_version }}
         - libtorch * cuda*
         - libvulkan-loader
         - openssl
-        - rdma-core
         - ucx {{ ucx_version }}
-        - yaml-cpp  {{ yaml_cpp_version }}
         - onnxruntime-cpp  {{ onnx_version }}
       run:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
         - {{ pin_compatible("cuda-version", max_pin="x") }}  # [cuda_compiler_version != "None"]
         - cloudpickle
-        - cuda-nvrtc        # needed on its own as libs depend on it
-        - cuda-nvrtc-dev    # holoscan wants to explicitly install cuda-nvrtc-dev
-        - cuda-nvtx         # needed to fix broken symlinks: libnvToolsExt.so.1.0.0 -> ../targets/x86_64-linux/lib/libnvToolsExt.so.1.0.0
-        - cudnn
+        - cuda-cudart
+        - cupy
         - dbus              # [aarch64]  # Without this, segfault happens during camera app test in https://github.com/nvidia-holoscan/holoscan-sdk/tree/main/python
         - libegl
-        - libcublas
-        - libcufft
-        - libcurand
-        - libcusolver
-        - libcusparse
         - libjpeg-turbo
-        - libnpp            # needed on its own as libs depend on it
-        - libnpp-dev        # holoscan wants to explicitly install libnpp-dev
-        - libnuma           # [aarch64]
-        - libnvjitlink
         - libtorch * cuda*
         - libvulkan-loader
-        - libzlib
-        - llvm-openmp 19.*
-        - nccl
-        - rdma-core
     test:
       commands:
         - test -L $PREFIX/lib/libholoscan_core.so.{{ abiversion }}
@@ -192,7 +175,6 @@ outputs:
         - {{ pin_subpackage("libholoscan", exact=True) }}
         - cuda-version {{ cuda_version }}
         - python ={{ python_version }}
-        - yaml-cpp  {{ yaml_cpp_version }}
       run:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
         - {{ pin_subpackage("libholoscan", exact=True) }}
@@ -269,12 +251,16 @@ outputs:
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
       host:
         - {{ pin_subpackage("libholoscan", exact=True) }}
-        - cuda-cudart-dev
         - cuda-version {{ cuda_version }}
         - python ={{ python_version }}
       run:
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
         - {{ pin_subpackage("libholoscan", exact=True) }}
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        - cuda-cudart
+        - cuda-cudart-dev   # holoscan wants to explicitly install this as it is needed for holoscan public interface
+        - cuda-nvrtc-dev    # holoscan wants to explicitly install this as it is needed for holoscan public interface
+        - libnpp-dev        # holoscan wants to explicitly install this as it is needed for holoscan public interface
+        - yaml-cpp          # holoscan wants to explicitly install this as it is needed for holoscan public interface
     test:
       requires:
         - cmake

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Thank you for installing holoscan! Please refer to https://github.com/nvidia-holoscan/holoscan-sdk/blob/main/scripts/README.md for how to use holoscan utility scripts under $CONDA_PREFIX/bin." >> "$PREFIX"/.messages.txt


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

**Note**: please do not approve this PR as the version will be bumped later when the next version is GA - this is an early attempt at getting this working and reviewed.

This PR enables a new subpackage (`libholoscan-dev`) to support C++ SDK usage case, which, until now, had been excluded from release due to internal issues.

I've moved `examples/` folder back into the `libholosca-dev` and removed the removal of revended `lib/libyaml-cpp*` because holoscan team has removed `libyaml` from the source tarball.

Also removed `README.md` from the package and instead created `post-link.sh` to refer to `README.md` for how to use holoscan utility scripts under `$CONDA_PREFIX/bin`

We won't be shipping `libyaml-cpp.a` but including it for cmake test to pass.

**Note**: please do not approve this PR as the version will be bumped later when the next version is GA - this is an early attempt at getting this working and reviewed.

<!--
Please add any other relevant info below:
-->
